### PR TITLE
Add stats and containers endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
 
 coverage/
+/pkg
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'pry'
+gem 'rake'
 gem 'simplecov'
 gem 'webmock'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     i18n (0.7.0)
-    json (1.8.2)
+    json (1.8.6)
     method_source (0.8.2)
     minitest (5.10.1)
     multi_json (1.12.1)
@@ -40,6 +40,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    rake (12.2.1)
     safe_yaml (1.0.4)
     simplecov (0.10.0)
       docile (~> 1.1.0)
@@ -62,9 +63,10 @@ PLATFORMS
 
 DEPENDENCIES
   pry
+  rake
   scalingo-ruby-api!
   simplecov
   webmock
 
 BUNDLED WITH
-   1.14.2
+   1.16.0

--- a/lib/scalingo/endpoint.rb
+++ b/lib/scalingo/endpoint.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module Scalingo
   module Endpoint
     def self.included(base)

--- a/lib/scalingo/endpoint/apps.rb
+++ b/lib/scalingo/endpoint/apps.rb
@@ -51,6 +51,7 @@ module Scalingo
 
       resources :addons
       resources :collaborators
+      resources :containers
       resources :deployments
       resources :domains
       resources :stats

--- a/lib/scalingo/endpoint/apps.rb
+++ b/lib/scalingo/endpoint/apps.rb
@@ -53,6 +53,7 @@ module Scalingo
       resources :collaborators
       resources :deployments
       resources :domains
+      resources :stats
       resources :variables
       resources :events, collection_only: true
     end

--- a/lib/scalingo/endpoint/containers.rb
+++ b/lib/scalingo/endpoint/containers.rb
@@ -1,0 +1,12 @@
+module Scalingo
+  module Endpoint
+    class Containers < Collection
+      def find_by
+        'name'
+      end
+    end
+
+    class Container < Resource
+    end
+  end
+end

--- a/lib/scalingo/endpoint/stats.rb
+++ b/lib/scalingo/endpoint/stats.rb
@@ -1,0 +1,9 @@
+module Scalingo
+  module Endpoint
+    class Stats < Collection
+    end
+
+    class Stat < Resource
+    end
+  end
+end


### PR DESCRIPTION
This adds access to [container stats](https://developers.scalingo.com/apps.html#get-real-time-stats-of-an-application).

Also:
  - Add rake in Gemfile
  - Upgrade json from 1.8.2 to 1.8.6 for ruby 2.4 compatibility
  - Ignore /pkg directory
  - Add `require 'ostruct'` so a `require 'scalingo'` does not fail with
    `NameError: uninitialized constant Scalingo::Endpoint::OpenStruct`
    error.